### PR TITLE
Feature: Nushell support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,17 +83,21 @@ jobs:
 
           Updated specification-driven development templates for GitHub Copilot, Claude Code, Gemini CLI, and Cursor.
 
-          Now includes per-script variants for POSIX shell (sh) and PowerShell (ps).
+          Now includes per-script variants for POSIX shell (sh), PowerShell (ps), and Nushell (nu).
 
           Download the template for your preferred AI assistant + script type:
           - spec-kit-template-copilot-sh-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-copilot-ps-${{ steps.get_tag.outputs.new_version }}.zip
+          - spec-kit-template-copilot-nu-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-claude-sh-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-claude-ps-${{ steps.get_tag.outputs.new_version }}.zip
+          - spec-kit-template-claude-nu-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-gemini-sh-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-gemini-ps-${{ steps.get_tag.outputs.new_version }}.zip
+          - spec-kit-template-gemini-nu-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-cursor-sh-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-cursor-ps-${{ steps.get_tag.outputs.new_version }}.zip
+          - spec-kit-template-cursor-nu-${{ steps.get_tag.outputs.new_version }}.zip
           EOF
           
           echo "Generated release notes:"
@@ -108,12 +112,16 @@ jobs:
           gh release create ${{ steps.get_tag.outputs.new_version }} \
             spec-kit-template-copilot-sh-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-copilot-ps-${{ steps.get_tag.outputs.new_version }}.zip \
+            spec-kit-template-copilot-nu-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-claude-sh-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-claude-ps-${{ steps.get_tag.outputs.new_version }}.zip \
+            spec-kit-template-claude-nu-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-gemini-sh-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-gemini-ps-${{ steps.get_tag.outputs.new_version }}.zip \
+            spec-kit-template-gemini-nu-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-cursor-sh-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-cursor-ps-${{ steps.get_tag.outputs.new_version }}.zip \
+            spec-kit-template-cursor-nu-${{ steps.get_tag.outputs.new_version }}.zip \
             --title "Spec Kit Templates - $VERSION_NO_V" \
             --notes-file release_notes.md
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,47 @@ When working on spec-kit:
 3. Test script functionality in the `scripts/` directory
 4. Ensure memory files (`memory/constitution.md`) are updated if major process changes are made
 
+## Building release template archives (maintainers)
+
+The GitHub Action in `.github/workflows/release.yml` automatically builds and publishes template archives for every push to `main` that modifies template-relevant paths. Archives follow the naming pattern:
+
+`spec-kit-template-<ai>-<script>-<version>.zip`
+
+Where:
+- `<ai>`: `claude`, `gemini`, `copilot`, or `cursor`
+- `<script>`: `sh` (POSIX shell), `ps` (PowerShell), or `nu` (Nushell)
+
+### Local build (verification prior to release)
+
+Prerequisites: `zip` must be installed and available on PATH.
+
+Examples:
+
+```bash
+# Build all agents for all script variants (sh, ps, nu)
+bash .github/workflows/scripts/create-release-packages.sh v0.0.1
+
+# Build only copilot sh variant
+AGENTS=copilot SCRIPTS=sh bash .github/workflows/scripts/create-release-packages.sh v0.0.1
+
+# Build only gemini + copilot nu variants
+AGENTS="gemini,copilot" SCRIPTS=nu bash .github/workflows/scripts/create-release-packages.sh v0.0.1
+```
+
+Resulting archives will be created in the repository root.
+
+### Adding / updating script variants
+
+When introducing a new script variant:
+1. Add its directory under `scripts/<variant-name>`
+2. Add `- <variant-key>` lines to each command template in `templates/commands/*.md`
+3. Insert a `<!-- VARIANT:<variant-key> - ... -->` line in `templates/plan-template.md`
+4. Extend the `ALL_SCRIPTS` array and `case` statement in `create-release-packages.sh`
+5. Update release notes section in `.github/workflows/release.yml`
+6. (Optional) Update CLI `--script` option choices in `src/specify_cli/__init__.py` if end‑user selection is needed
+
+Nushell (`nu`) support has already been integrated following the above pattern.
+
 ## Resources
 
 - [Spec-Driven Development Methodology](./spec-driven.md)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,29 @@ Our research and experimentation focus on:
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
 
+### Optional Shell Environments
+
+In addition to the provided Bash (`scripts/bash`) and PowerShell (`scripts/powershell`) automation scripts, this repository now includes Nushell equivalents in `scripts/nushell`. If you use [Nushell](https://www.nushell.sh/), you can run the same feature workflow commands:
+
+```bash
+# Create a new feature (generates numbered branch & spec skeleton)
+scripts/nushell/create-new-feature.nu "Add photo album sharing"
+
+# Set up implementation plan template
+scripts/nushell/setup-plan.nu
+
+# Show derived feature paths
+scripts/nushell/get-feature-paths.nu
+
+# Validate prerequisites before running /tasks
+scripts/nushell/check-task-prerequisites.nu
+
+# Update agent context files (CLAUDE.md, etc.)
+scripts/nushell/update-agent-context.nu claude
+```
+
+All Nushell scripts support similar flags as their Bash counterparts (e.g., `--json` where applicable) for integration into tooling.
+
 ## 📖 Learn more
 
 - **[Complete Spec-Driven Development Methodology](./spec-driven.md)** - Deep dive into the full process

--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ scripts/nushell/update-agent-context.nu claude
 
 All Nushell scripts support similar flags as their Bash counterparts (e.g., `--json` where applicable) for integration into tooling.
 
+### Script Variants & `--script` Flag
+
+When running `specify init`, you can choose which script variant to download with the `--script` flag:
+
+```bash
+specify init my-project --ai claude --script sh   # POSIX (bash/zsh)
+specify init my-project --ai claude --script ps   # PowerShell
+specify init my-project --ai claude --script nu   # Nushell
+```
+
+If `--script` isn't provided, the CLI defaults to:
+- `sh` on Linux/macOS
+- `ps` on Windows
+
+The command templates under `templates/commands/` expose a `scripts:` mapping with keys `sh`, `ps`, and `nu`. The active agent runtime substitutes `{SCRIPT}` with the appropriate line based on environment or selection. Adding Nushell provides seamless parity without changing higher-level automation logic.
+
+Recommendation: Commit all three variants in long-lived repos so contributors can use their preferred shell.
+
 ## 📖 Learn more
 
 - **[Complete Spec-Driven Development Methodology](./spec-driven.md)** - Deep dive into the full process

--- a/scripts/nushell/check-task-prerequisites.nu
+++ b/scripts/nushell/check-task-prerequisites.nu
@@ -1,0 +1,31 @@
+#!/usr/bin/env nu
+# Nushell port of bash/check-task-prerequisites.sh
+use ./common.nu *
+
+export def main [...args] {
+  mut json_mode = false
+  for a in $args { if $a in ['--json'] { $json_mode = true } else if $a in ['--help' '-h'] { print 'Usage: check-task-prerequisites.nu [--json]'; return } }
+
+  let paths = (get_feature_paths)
+  try { check_feature_branch $paths.CURRENT_BRANCH } catch {|err| print $err.msg; exit 1 }
+  if not ($paths.FEATURE_DIR | path exists) { print $"ERROR: Feature directory not found: ($paths.FEATURE_DIR)\nRun /specify first."; exit 1 }
+  if not ($paths.IMPL_PLAN | path exists) { print $"ERROR: plan.md not found in ($paths.FEATURE_DIR)\nRun /plan first."; exit 1 }
+
+  if $json_mode {
+    mut docs = []
+    if ($paths.RESEARCH | path exists) { $docs ++= ['research.md'] }
+    if ($paths.DATA_MODEL | path exists) { $docs ++= ['data-model.md'] }
+    if ($paths.CONTRACTS_DIR | path exists) and ((ls $paths.CONTRACTS_DIR | length) > 0) { $docs ++= ['contracts/'] }
+    if ($paths.QUICKSTART | path exists) { $docs ++= ['quickstart.md'] }
+    { FEATURE_DIR: $paths.FEATURE_DIR AVAILABLE_DOCS: $docs } | to json -r
+  } else {
+    print $"FEATURE_DIR:($paths.FEATURE_DIR)"
+    print 'AVAILABLE_DOCS:'
+    print (check_file $paths.RESEARCH 'research.md')
+    print (check_file $paths.DATA_MODEL 'data-model.md')
+    print (check_dir $paths.CONTRACTS_DIR 'contracts/')
+    print (check_file $paths.QUICKSTART 'quickstart.md')
+  }
+}
+
+main

--- a/scripts/nushell/common.nu
+++ b/scripts/nushell/common.nu
@@ -1,0 +1,54 @@
+#!/usr/bin/env nu
+# Common Nushell utilities mirroring bash/common.sh
+
+export def get_repo_root [] {
+  git rev-parse --show-toplevel | str trim
+}
+
+export def get_current_branch [] {
+  git rev-parse --abbrev-ref HEAD | str trim
+}
+
+# Returns error (non-zero) if not a feature branch (expects NNN- prefix)
+export def check_feature_branch [branch:string] {
+  if not ($branch =~ '^[0-9]{3}-') {
+    error make { msg: $"ERROR: Not on a feature branch. Current branch: ($branch)\nFeature branches should be named like: 001-feature-name" }
+  }
+  $branch
+}
+
+export def get_feature_dir [repo_root:string branch:string] {
+  $"($repo_root)/specs/($branch)"
+}
+
+# Emit record of common feature paths
+export def get_feature_paths [] {
+  let repo_root = (get_repo_root)
+  let current_branch = (get_current_branch)
+  let feature_dir = (get_feature_dir $repo_root $current_branch)
+  {
+    REPO_ROOT: $repo_root
+    CURRENT_BRANCH: $current_branch
+    FEATURE_DIR: $feature_dir
+    FEATURE_SPEC: $"($feature_dir)/spec.md"
+    IMPL_PLAN: $"($feature_dir)/plan.md"
+    TASKS: $"($feature_dir)/tasks.md"
+    RESEARCH: $"($feature_dir)/research.md"
+    DATA_MODEL: $"($feature_dir)/data-model.md"
+    QUICKSTART: $"($feature_dir)/quickstart.md"
+    CONTRACTS_DIR: $"($feature_dir)/contracts"
+  }
+}
+
+# Helpers to indicate presence of file/dir
+export def check_file [path:string label:string] {
+  if ($path | path exists) {
+    $"  ✓ ($label)"
+  } else { $"  ✗ ($label)" }
+}
+
+export def check_dir [path:string label:string] {
+  if ($path | path exists) and ($path | path type) == 'dir' and ((ls $path | length) > 0) {
+    $"  ✓ ($label)"
+  } else { $"  ✗ ($label)" }
+}

--- a/scripts/nushell/create-new-feature.nu
+++ b/scripts/nushell/create-new-feature.nu
@@ -1,0 +1,55 @@
+#!/usr/bin/env nu
+# Create a new feature (Nushell port of bash/create-new-feature.sh)
+
+use ./common.nu *
+
+def help [] { print 'Usage: create-new-feature.nu [--json] <feature description>'; }
+
+export def main [...args] {
+  mut json_mode = false
+  mut parts = []
+  for a in $args {
+    match $a {
+      '--json' => { $json_mode = true }
+      '--help' | '-h' => { help; return }
+      _ => { $parts ++= [$a] }
+    }
+  }
+  let feature_description = ($parts | str join ' ' | str trim)
+  if ($feature_description | is-empty) { help; error make { msg: 'Feature description required' } }
+
+  let repo_root = (get_repo_root)
+  let specs_dir = $"($repo_root)/specs"
+  mkdir $specs_dir
+
+  # determine highest existing NNN prefix
+  let existing_numbers = (ls $specs_dir | where type == 'dir' | get name | path basename | parse -r '^(?P<num>[0-9]+)-' | default {num: []} | get num | each { |n| $n | into int } )
+  let highest = (if ($existing_numbers | is-empty) {0} else { $existing_numbers | math max })
+  let next = $highest + 1
+  let feature_num = ($next | into string | fill -a r -w 3 -c '0')
+
+  # sanitize branch slug
+  mut branch_name = ($feature_description | str downcase | str replace -a -r '[^a-z0-9]+' '-' | str trim -c '-')
+  # take first 3 words
+  let words = ($branch_name | split row '-' | where { |it| $it != '' } | take 3 | str join '-')
+  $branch_name = $"($feature_num)-($words)"
+
+  # create branch
+  git checkout -b $branch_name | ignore
+
+  let feature_dir = $"($specs_dir)/($branch_name)"
+  mkdir $feature_dir
+
+  let template = $"($repo_root)/templates/spec-template.md"
+  let spec_file = $"($feature_dir)/spec.md"
+  if ($template | path exists) { cp $template $spec_file } else { touch $spec_file }
+
+  if $json_mode {
+    { BRANCH_NAME: $branch_name SPEC_FILE: $spec_file FEATURE_NUM: $feature_num } | to json -r
+  } else {
+    print $"BRANCH_NAME: ($branch_name)"; print $"SPEC_FILE: ($spec_file)"; print $"FEATURE_NUM: ($feature_num)"
+  }
+}
+
+# Run if executed directly (simple heuristic)
+if (scope modules | where name == (pwd) | length) == 0 { main $env.CMDLINE_ARGS? } # fallback; typical usage: nu create-new-feature.nu ...

--- a/scripts/nushell/get-feature-paths.nu
+++ b/scripts/nushell/get-feature-paths.nu
@@ -1,0 +1,17 @@
+#!/usr/bin/env nu
+# Nushell port of bash/get-feature-paths.sh
+use ./common.nu *
+
+export def main [] {
+  let paths = (get_feature_paths)
+  let branch = $paths.CURRENT_BRANCH
+  try { check_feature_branch $branch } catch {|err| print $err.msg; exit 1 }
+  print $"REPO_ROOT: ($paths.REPO_ROOT)"
+  print $"BRANCH: ($branch)"
+  print $"FEATURE_DIR: ($paths.FEATURE_DIR)"
+  print $"FEATURE_SPEC: ($paths.FEATURE_SPEC)"
+  print $"IMPL_PLAN: ($paths.IMPL_PLAN)"
+  print $"TASKS: ($paths.TASKS)"
+}
+
+main

--- a/scripts/nushell/setup-plan.nu
+++ b/scripts/nushell/setup-plan.nu
@@ -1,0 +1,31 @@
+#!/usr/bin/env nu
+# Nushell port of bash/setup-plan.sh
+use ./common.nu *
+
+export def main [...args] {
+  mut json_mode = false
+  for a in $args { if $a in ['--json'] { $json_mode = true } else if $a in ['--help' '-h'] { print 'Usage: setup-plan.nu [--json]'; return } }
+
+  let paths = (get_feature_paths)
+  try { check_feature_branch $paths.CURRENT_BRANCH } catch {|err| print $err.msg; exit 1 }
+  mkdir $paths.FEATURE_DIR
+
+  # Template path (keeping legacy bash path fallback .specify/templates)
+  let template_primary = $"($paths.REPO_ROOT)/.specify/templates/plan-template.md"
+  let template_alt = $"($paths.REPO_ROOT)/templates/plan-template.md"
+  if ($template_primary | path exists) {
+    cp $template_primary $paths.IMPL_PLAN
+  } else if ($template_alt | path exists) {
+    cp $template_alt $paths.IMPL_PLAN
+  } else {
+    touch $paths.IMPL_PLAN
+  }
+
+  if $json_mode {
+    { FEATURE_SPEC: $paths.FEATURE_SPEC IMPL_PLAN: $paths.IMPL_PLAN SPECS_DIR: $paths.FEATURE_DIR BRANCH: $paths.CURRENT_BRANCH } | to json -r
+  } else {
+    print $"FEATURE_SPEC: ($paths.FEATURE_SPEC)"; print $"IMPL_PLAN: ($paths.IMPL_PLAN)"; print $"SPECS_DIR: ($paths.FEATURE_DIR)"; print $"BRANCH: ($paths.CURRENT_BRANCH)"
+  }
+}
+
+main

--- a/scripts/nushell/update-agent-context.nu
+++ b/scripts/nushell/update-agent-context.nu
@@ -1,0 +1,106 @@
+#!/usr/bin/env nu
+# Nushell port of bash/update-agent-context.sh
+# Updates agent context files (CLAUDE.md, GEMINI.md, .github/copilot-instructions.md) based on current feature plan
+
+export def main [agent_type?:string] {
+  let repo_root = (git rev-parse --show-toplevel | str trim)
+  let current_branch = (git rev-parse --abbrev-ref HEAD | str trim)
+  let feature_dir = $"($repo_root)/specs/($current_branch)"
+  let new_plan = $"($feature_dir)/plan.md"
+  if not ($new_plan | path exists) { print $"ERROR: No plan.md found at ($new_plan)"; exit 1 }
+
+  print $"=== Updating agent context files for feature ($current_branch) ==="
+
+  let read_line = {|pattern| (open $new_plan | lines | find -r $pattern | first? | default '' | str replace -r '^\*\*[^:]+\*\*: ' '' ) }
+  let new_lang = (do $read_line '^\*\*Language/Version\*\*:' | str trim | if ($in =~ 'NEEDS CLARIFICATION') { '' } else { $in })
+  let new_framework = (do $read_line '^\*\*Primary Dependencies\*\*:' | str trim | if ($in =~ 'NEEDS CLARIFICATION') { '' } else { $in })
+  let new_db = (do $read_line '^\*\*Storage\*\*:' | str trim | if ($in =~ 'NEEDS CLARIFICATION' or $in == 'N/A') { '' } else { $in })
+  let new_project_type = (do $read_line '^\*\*Project Type\*\*:' | str trim)
+
+  let claude_file = $"($repo_root)/CLAUDE.md"
+  let gemini_file = $"($repo_root)/GEMINI.md"
+  let copilot_file = $"($repo_root)/.github/copilot-instructions.md"
+
+  def infer_commands [] {
+    if ($new_lang =~ 'Python') { 'cd src && pytest && ruff check .' } 
+    else if ($new_lang =~ 'Rust') { 'cargo test && cargo clippy' } 
+    else if ($new_lang =~ 'JavaScript' or $new_lang =~ 'TypeScript') { 'npm test && npm run lint' } 
+    else { $"# Add commands for ($new_lang)" }
+  }
+
+  def ensure_file [target:string agent_name:string] {
+    if not ($target | path exists) {
+      print $"Creating new ($agent_name) context file..."
+      let template = $"($repo_root)/templates/agent-file-template.md"
+      if not ($template | path exists) { print 'ERROR: Template not found'; return }
+      let content = (open $template | str join) # open returns structured lines sometimes; flatten
+      let tech_line = $"- ($new_lang) + ($new_framework) ($current_branch)"
+      let structure = (if ($new_project_type =~ 'web') { "backend/\nfrontend/\ntests/" } else { "src/\ntests/" })
+      let commands = (infer_commands)
+      let updated = ($content 
+        | str replace '[PROJECT NAME]' (basename $repo_root)
+        | str replace '[DATE]' (date now | format date '%Y-%m-%d')
+        | str replace '[EXTRACTED FROM ALL PLAN.MD FILES]' $tech_line
+        | str replace '[ACTUAL STRUCTURE FROM PLANS]' $structure
+        | str replace '[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES]' $commands
+        | str replace '[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]' $"($new_lang): Follow standard conventions"
+        | str replace '[LAST 3 FEATURES AND WHAT THEY ADDED]' $"- ($current_branch): Added ($new_lang) + ($new_framework)" )
+      $updated | save -f $target
+      print $"✅ ($agent_name) context file created"
+    } else {
+      update_existing $target $agent_name
+    }
+  }
+
+  def update_existing [target:string agent_name:string] {
+    print $"Updating existing ($agent_name) context file..."
+    mut content = (open $target | str join)
+    # Active Technologies section append if missing
+    if ($new_lang != '' and ($content | str contains $new_lang) == false) {
+      $content = ($content | str replace -r '## Active Technologies\n' $"## Active Technologies\n- ($new_lang) + ($new_framework) ($current_branch)\n")
+    }
+    if ($new_db != '' and ($content | str contains $new_db) == false) {
+      $content = ($content | str replace -r '## Active Technologies\n' $"## Active Technologies\n- ($new_db) ($current_branch)\n")
+    }
+    # Recent Changes - prepend
+    if ($content | str contains '## Recent Changes') {
+      # naive extraction: split on header and reconstruct
+      let parts = ($content | split row '## Recent Changes')
+      if ($parts | length) > 1 {
+        let tail = ($parts | skip 1 | str join '## Recent Changes')
+        let after_header = ($tail | split row '\n' | skip 1) # skip first newline after header
+        let existing = ($after_header | take 5 | where {|l| ($l | str starts-with '-') } | take 2)
+        let new_block = ([$"- ($current_branch): Added ($new_lang) + ($new_framework)" ] | append $existing | str join "\n")
+        $content = ($content | str replace '## Recent Changes' $"## Recent Changes\n($new_block)")
+      }
+    }
+    # Update last updated date
+    $content = ($content | str replace -r 'Last updated: [0-9]{4}-[0-9]{2}-[0-9]{2}' $"Last updated: (date now | format date '%Y-%m-%d')")
+    $content | save -f $target
+    print $"✅ ($agent_name) context file updated successfully"
+  }
+
+  match $agent_type {
+    'claude' => { ensure_file $claude_file 'Claude Code' }
+    'gemini' => { ensure_file $gemini_file 'Gemini CLI' }
+    'copilot' => { ensure_file $copilot_file 'GitHub Copilot' }
+    '' => {
+      # update existing or create Claude by default
+      if ($claude_file | path exists) { ensure_file $claude_file 'Claude Code' }
+      if ($gemini_file | path exists) { ensure_file $gemini_file 'Gemini CLI' }
+      if ($copilot_file | path exists) { ensure_file $copilot_file 'GitHub Copilot' }
+      if (not ($claude_file | path exists) and not ($gemini_file | path exists) and not ($copilot_file | path exists)) { ensure_file $claude_file 'Claude Code' }
+    }
+    _ => { print $"ERROR: Unknown agent type '($agent_type)'"; exit 1 }
+  }
+
+  print ''
+  print 'Summary of changes:'
+  if $new_lang != '' { print $"- Added language: ($new_lang)" }
+  if $new_framework != '' { print $"- Added framework: ($new_framework)" }
+  if $new_db != '' { print $"- Added database: ($new_db)" }
+  print ''
+  print 'Usage: update-agent-context.nu [claude|gemini|copilot]'
+}
+
+main

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -28,7 +28,6 @@ import sys
 import zipfile
 import tempfile
 import shutil
-import json
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -416,14 +415,69 @@ def init_git_repo(project_path: Path, quiet: bool = False) -> bool:
         os.chdir(original_cwd)
 
 
-def download_template_from_github(ai_assistant: str, download_dir: Path, *, script_type: str = "sh", verbose: bool = True, show_progress: bool = True, client: httpx.Client = None, debug: bool = False) -> Tuple[Path, dict]:
-    repo_owner = "github"
-    repo_name = "spec-kit"
+def download_template_from_github(
+    ai_assistant: str,
+    download_dir: Path,
+    *,
+    script_type: str = "sh",
+    repo_owner: str | None = None,
+    repo_name: str = "spec-kit",
+    verbose: bool = True,
+    show_progress: bool = True,
+    client: httpx.Client = None,
+    debug: bool = False,
+) -> Tuple[Path, dict]:
+    """Download template ZIP for the given assistant from a GitHub release.
+
+    Repo owner resolution order (if ``repo_owner`` not passed):
+      1. GitHub CLI: ``gh repo view --json nameWithOwner`` (extract owner)
+      2. Environment variable ``SPEC_KIT_REPO_OWNER``
+      3. Fallback default: ``github``
+
+    This enables contributors to publish releases to personal forks for testing
+    without changing code. The resolved owner and source are included in the
+    returned metadata under keys ``repo_owner`` and ``owner_source``.
+    """
+    resolved_owner_source: str | None = None
+    if repo_owner:
+        resolved_owner_source = "argument"
+    else:
+        # Attempt GitHub CLI detection
+        try:
+            gh_path = shutil.which("gh")
+            if gh_path:
+                gh_proc = subprocess.run(
+                    [gh_path, "repo", "view", "--json", "nameWithOwner"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                import json as _json
+                data = _json.loads(gh_proc.stdout or "{}")
+                name_with_owner = data.get("nameWithOwner") or ""
+                if "/" in name_with_owner:
+                    repo_owner = name_with_owner.split("/", 1)[0]
+                    resolved_owner_source = "gh-cli"
+        except Exception:
+            pass  # ignore any gh detection errors
+    if not repo_owner:
+        env_owner = os.environ.get("SPEC_KIT_REPO_OWNER")
+        if env_owner:
+            repo_owner = env_owner.strip()
+            resolved_owner_source = "env"
+    if not repo_owner:
+        repo_owner = "github"
+        if not resolved_owner_source:
+            resolved_owner_source = "default"
+
     if client is None:
         client = httpx.Client(verify=ssl_context)
     
     if verbose:
         console.print("[cyan]Fetching latest release information...[/cyan]")
+        if debug:
+            console.print(f"[dim]Using repo owner: {repo_owner} (source: {resolved_owner_source})[/dim]")
     api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest"
     
     try:
@@ -439,7 +493,7 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
         except ValueError as je:
             raise RuntimeError(f"Failed to parse release JSON: {je}\nRaw (truncated 400): {response.text[:400]}")
     except Exception as e:
-        console.print(f"[red]Error fetching release information[/red]")
+        console.print("[red]Error fetching release information[/red]")
         console.print(Panel(str(e), title="Fetch Error", border_style="red"))
         raise typer.Exit(1)
     
@@ -470,7 +524,7 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
     # Download the file
     zip_path = download_dir / filename
     if verbose:
-        console.print(f"[cyan]Downloading template...[/cyan]")
+        console.print("[cyan]Downloading template...[/cyan]")
     
     try:
         with client.stream("GET", download_url, timeout=60, follow_redirects=True) as response:
@@ -500,7 +554,7 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
                         for chunk in response.iter_bytes(chunk_size=8192):
                             f.write(chunk)
     except Exception as e:
-        console.print(f"[red]Error downloading template[/red]")
+        console.print("[red]Error downloading template[/red]")
         detail = str(e)
         if zip_path.exists():
             zip_path.unlink()
@@ -512,12 +566,25 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
         "filename": filename,
         "size": file_size,
         "release": release_data["tag_name"],
-        "asset_url": download_url
+        "asset_url": download_url,
+        "repo_owner": repo_owner,
+        "owner_source": resolved_owner_source,
     }
     return zip_path, metadata
 
 
-def download_and_extract_template(project_path: Path, ai_assistant: str, script_type: str, is_current_dir: bool = False, *, verbose: bool = True, tracker: StepTracker | None = None, client: httpx.Client = None, debug: bool = False) -> Path:
+def download_and_extract_template(
+    project_path: Path,
+    ai_assistant: str,
+    script_type: str,
+    repo_owner: str | None = None,
+    is_current_dir: bool = False,
+    *,
+    verbose: bool = True,
+    tracker: StepTracker | None = None,
+    client: httpx.Client = None,
+    debug: bool = False,
+) -> Path:
     """Download the latest release and extract it to create a new project.
     Returns project_path. Uses tracker if provided (with keys: fetch, download, extract, cleanup)
     """
@@ -531,10 +598,11 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
             ai_assistant,
             current_dir,
             script_type=script_type,
+            repo_owner=repo_owner,
             verbose=verbose and tracker is None,
             show_progress=(tracker is None),
             client=client,
-            debug=debug
+            debug=debug,
         )
         if tracker:
             tracker.complete("fetch", f"release {meta['release']} ({meta['size']:,} bytes)")
@@ -590,7 +658,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
                             tracker.add("flatten", "Flatten nested directory")
                             tracker.complete("flatten")
                         elif verbose:
-                            console.print(f"[cyan]Found nested directory structure[/cyan]")
+                            console.print("[cyan]Found nested directory structure[/cyan]")
                     
                     # Copy contents to current directory
                     for item in source_dir.iterdir():
@@ -613,7 +681,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
                                 console.print(f"[yellow]Overwriting file:[/yellow] {item.name}")
                             shutil.copy2(item, dest_path)
                     if verbose and not tracker:
-                        console.print(f"[cyan]Template files merged into current directory[/cyan]")
+                        console.print("[cyan]Template files merged into current directory[/cyan]")
             else:
                 # Extract directly to project directory (original behavior)
                 zip_ref.extractall(project_path)
@@ -643,7 +711,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
                         tracker.add("flatten", "Flatten nested directory")
                         tracker.complete("flatten")
                     elif verbose:
-                        console.print(f"[cyan]Flattened nested directory structure[/cyan]")
+                        console.print("[cyan]Flattened nested directory structure[/cyan]")
                     
     except Exception as e:
         if tracker:
@@ -730,6 +798,7 @@ def init(
     project_name: str = typer.Argument(None, help="Name for your new project directory (optional if using --here)"),
     ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, or cursor"),
     script_type: str = typer.Option(None, "--script", help="Script type to use: sh, ps or nu"),
+    repo_owner: str = typer.Option(None, "--repo-owner", help="Override GitHub repo owner for template releases (default auto-detect via gh or SPEC_KIT_REPO_OWNER)"),
     ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Skip checks for AI agent tools like Claude Code"),
     no_git: bool = typer.Option(False, "--no-git", help="Skip git repository initialization"),
     here: bool = typer.Option(False, "--here", help="Initialize project in the current directory instead of creating a new one"),
@@ -891,7 +960,17 @@ def init(
             local_ssl_context = ssl_context if verify else False
             local_client = httpx.Client(verify=local_ssl_context)
 
-            download_and_extract_template(project_path, selected_ai, selected_script, here, verbose=False, tracker=tracker, client=local_client, debug=debug)
+            download_and_extract_template(
+                project_path,
+                selected_ai,
+                selected_script,
+                repo_owner=repo_owner,
+                is_current_dir=here,
+                verbose=False,
+                tracker=tracker,
+                client=local_client,
+                debug=debug,
+            )
 
             # Ensure scripts are executable (POSIX)
             ensure_executable_scripts(project_path, tracker=tracker)

--- a/templates/agent-file-template.md
+++ b/templates/agent-file-template.md
@@ -13,6 +13,13 @@ Auto-generated from all feature plans. Last updated: [DATE]
 ## Commands
 [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES]
 
+Shell Script Variants:
+- Bash: scripts/bash/*.sh
+- PowerShell: scripts/powershell/*.ps1
+- Nushell: scripts/nushell/*.nu
+
+Use the matching variant for your environment; behavior is equivalent across shells.
+
 ## Code Style
 [LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE]
 

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -3,6 +3,7 @@ description: Execute the implementation planning workflow using the plan templat
 scripts:
   sh: scripts/bash/setup-plan.sh --json
   ps: scripts/powershell/setup-plan.ps1 -Json
+   nu: scripts/nushell/setup-plan.nu --json
 ---
 
 Given the implementation details provided as an argument, do this:

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -3,6 +3,7 @@ description: Create or update the feature specification from a natural language 
 scripts:
   sh: scripts/bash/create-new-feature.sh --json "{ARGS}"
   ps: scripts/powershell/create-new-feature.ps1 -Json "{ARGS}"
+  nu: scripts/nushell/create-new-feature.nu --json {ARGS}
 ---
 
 Given the feature description provided as an argument, do this:

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -3,6 +3,7 @@ description: Generate an actionable, dependency-ordered tasks.md for the feature
 scripts:
   sh: scripts/bash/check-task-prerequisites.sh --json
   ps: scripts/powershell/check-task-prerequisites.ps1 -Json
+   nu: scripts/nushell/check-task-prerequisites.nu --json
 ---
 
 Given the context provided as an argument, do this:

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -2,6 +2,7 @@
 
 <!-- VARIANT:sh - Run `/scripts/bash/update-agent-context.sh __AGENT__` for your AI assistant -->
 <!-- VARIANT:ps - Run `/scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__` for your AI assistant -->
+<!-- VARIANT:nu - Run `scripts/nushell/update-agent-context.nu __AGENT__` for your AI assistant -->
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -5,6 +5,8 @@
 **Status**: Draft  
 **Input**: User description: "$ARGUMENTS"
 
+_Note: Subsequent planning and task generation scripts are available in Bash, PowerShell, and Nushell under `scripts/`._
+
 ## Execution Flow (main)
 ```
 1. Parse user description from Input

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -3,6 +3,8 @@
 **Input**: Design documents from `/specs/[###-feature-name]/`
 **Prerequisites**: plan.md (required), research.md, data-model.md, contracts/
 
+Shell Variants: Bash (scripts/bash), PowerShell (scripts/powershell), Nushell (scripts/nushell) – use any equivalent to gather prerequisites.
+
 ## Execution Flow (main)
 ```
 1. Load plan.md from feature directory


### PR DESCRIPTION
This pull request adds full support for Nushell (`nu`) script variants across the project, including new Nushell automation scripts, updates to the release packaging workflow, and documentation improvements. This ensures parity between Bash, PowerShell, and Nushell for all feature workflow commands, and allows users to select their preferred shell environment.

**Nushell Integration and Script Variant Support**

* Added Nushell equivalents for all core automation scripts in `scripts/nushell/`, including `create-new-feature.nu`, `setup-plan.nu`, `get-feature-paths.nu`, and `check-task-prerequisites.nu`, along with a shared `common.nu` utility module. These scripts mirror the functionality of their Bash counterparts and support a `--json` flag for tooling integration. [[1]](diffhunk://#diff-4b35bea91f7b134df2e081cb8712853de9090b177a4d5ee6e7858fb24df105f8R1-R55) [[2]](diffhunk://#diff-ad7f207e68f6c75560659d4068c33afd03405570559d2b4d3bd4e6e3c0fc98b8R1-R31) [[3]](diffhunk://#diff-e8d72e16e96f8b130e8f1d0531f3ad9d5569eb814e870d97bcbead688abcb58fR1-R17) [[4]](diffhunk://#diff-f779f882988136169abd3aba858c46ab63bbf50750bb2fb1aa0e4a879a17998dR1-R31) [[5]](diffhunk://#diff-ce9402cdebdfccb9bab2955876e2879a4ef87acb30f88b65e3577606ebd08d85R1-R54)

* Updated the release packaging workflow in `.github/workflows/release.yml` and `.github/workflows/scripts/create-release-packages.sh` to:
  - Include `nu` as a supported script variant alongside `sh` and `ps`
  - Package and publish Nushell template archives for each AI agent
  - Add integrity checks for the presence of variant directories [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L86-R100) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R115-R124) [[3]](diffhunk://#diff-89b37c99301c19b14007c31f71bbb29831eccbb2faa5cf45996063130403ca60L10-R15) [[4]](diffhunk://#diff-89b37c99301c19b14007c31f71bbb29831eccbb2faa5cf45996063130403ca60R110-R114) [[5]](diffhunk://#diff-89b37c99301c19b14007c31f71bbb29831eccbb2faa5cf45996063130403ca60L120-R126) [[6]](diffhunk://#diff-89b37c99301c19b14007c31f71bbb29831eccbb2faa5cf45996063130403ca60R150-R166) [[7]](diffhunk://#diff-89b37c99301c19b14007c31f71bbb29831eccbb2faa5cf45996063130403ca60L155-R189)

**Documentation Updates**

* Expanded `README.md` to document Nushell support, provide usage examples for Nushell scripts, and explain the `--script` flag for selecting variants during project initialization.

* Added a new section to `CONTRIBUTING.md` detailing how to build and extend release template archives for new script variants, including step-by-step instructions for maintainers and confirmation of Nushell integration.